### PR TITLE
add multi node training script and memory profiling utils for sanity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,43 @@ This codebase provides..
 ---
 # Usage
 
-Single Node training:
-
+- Install:
 
 ```bash
 git clone https://github.com/cloneofsimo/min-max-gpt
 cd min-max-gpt
 pip install -r requirements.txt
+```
+
+- Single Node training:
+
+```bash
+ROOT_DIR=/path/to/dir/min-max-gpt
+cd $ROOT_DIR
 export WORLD_SIZE=$(nvidia-smi -L | wc -l)
 deepspeed --num_gpus $WORLD_SIZE run_trainer.py --lr 1e-4 --width 32 --run_name "test"
 ```
 
-Multi-node training:
+- Multi-node training:
 
-Coming up soon.
+You should create hostfile and specify environemnt variables.
+Nodes must be able to access each other with passwordless SSH.
+
+```bash
+$ cat /path/to/dir/min-max-gpt/hostfile
+xxx.xxx.xxx.xxx slots=8 #node0 ip, #num_gpus
+xxx.xxx.xxx.xxx slots=8 #node1 ip, #num_gpus
+```
+
+```bash
+ROOT_DIR=/path/to/dir/min-max-gpt
+cd $ROOT_DIR
+export HOST_FILE_PATH=$ROOT_DIR/hostfile
+export NGPU_PER_NODE=?? # e.g. 8
+export NUM_NODES=?? # e.g. 2
+export SINGLE_RUN=True
+./run_multi_node.sh $HOST_FILE_PATH $NGPU_PER_NODE $NUM_NODES $SINGLE_RUN
+```
 
 ---
 

--- a/memory_profile_utils.py
+++ b/memory_profile_utils.py
@@ -1,0 +1,58 @@
+import gc
+import psutil
+import subprocess as sp
+
+import torch
+from deepspeed.utils import logger
+
+
+def print_memory_with_message(rank, device, message:str=None):
+    if rank == 0:
+        if None is not None:
+            logger.info('====='*2 + message + '====='*2 + '\n')
+        get_nvidia_gpu_memory()
+    torch.distributed.barrier()
+
+    gpu_memory_plot_helper(rank, device, message)
+    torch.distributed.barrier()
+
+def get_nvidia_gpu_memory():
+    output_to_list = lambda x: x.decode('ascii').split('\n')[:-1]
+    ACCEPTABLE_AVAILABLE_MEMORY = 1024
+    COMMAND = "nvidia-smi --query-gpu=memory.used --format=csv"
+    try:
+        memory_use_info = output_to_list(sp.check_output(COMMAND.split(),stderr=sp.STDOUT))[1:]
+    except sp.CalledProcessError as e:
+        raise RuntimeError("command '{}' return with error (code {}): {}".format(e.cmd, e.returncode, e.output))
+    memory_use_values = [int(x.split()[0]) for i, x in enumerate(memory_use_info)]
+    logger.info(f'''
+    nvidia-smi info
+    {memory_use_values}''')
+
+def gpu_memory_plot_helper(
+    rank,
+    device, 
+    use_deepspeed_memory_usage_helper: bool = False,
+):
+    '''
+    DeepSpeed has its own memory profiler, but we add this for customization in the future.
+    https://github.com/microsoft/DeepSpeed/blob/ff7d5275f2aa916cb5f320e0d817154e96f9cdb6/deepspeed/runtime/utils.py#L793
+    '''
+    gc.collect()
+    torch.cuda.synchronize(device) # https://pytorch.org/docs/stable/generated/torch.cuda.synchronize.html
+    
+    allocated = torch.cuda.memory_allocated(device) / (1024**2)
+    max_allocated = torch.cuda.max_memory_allocated(device) / (1024**2)
+    reserved = torch.cuda.memory_reserved(device) / (1024**2)
+    max_reserved = torch.cuda. max_memory_reserved(device) / (1024**2)
+
+    vm_stats = psutil.virtual_memory()
+    used_GB = round(((vm_stats.total - vm_stats.available) / (1024**3)), 2)
+
+    logger.info(
+    f'''
+    rank: {rank} / device: {device}
+    CPU Virtual Memory:  used = {used_GB} GB, percent = {vm_stats.percent}%
+    Allocated / Reserved: {allocated:.2f}MB / {reserved:.2f}MB
+    Max Allocated / Max Reserved: {max_allocated:.2f}MB / {max_reserved:.2f}MB''')
+    torch.cuda.reset_peak_memory_stats(device) # https://pytorch.org/docs/stable/generated/torch.cuda.reset_peak_memory_stats.html

--- a/run.sh
+++ b/run.sh
@@ -1,12 +1,24 @@
-export WORLD_SIZE=$(nvidia-smi -L | wc -l)
 #!/bin/bash
+export WORLD_SIZE=$(nvidia-smi -L | wc -l)
+export SINGLE_RUN=True # True or False
 
-lrs=(5e-4)
-widths=(16 32 64 128)
+if [ "$SINGLE_RUN" = "True" ]; then
+    # single run test
+    deepspeed --num_gpus $WORLD_SIZE \
+    run_trainer.py \
+    --lr 5e-4 \
+    --width 16 \
+    --run_name "single_node_test" \
+    --print_profile_results
+else
+    # recursive run
+    lrs=(5e-4, 1e-4)
+    widths=(16 32 64 128)
 
-for lr in "${lrs[@]}"; do
-    for width in "${widths[@]}"; do
-        run_name="lr_${lr}_width_${width}"
-        deepspeed --num_gpus $WORLD_SIZE run_trainer.py --lr $lr --width $width --run_name $run_name
+    for lr in "${lrs[@]}"; do
+        for width in "${widths[@]}"; do
+            run_name="lr_${lr}_width_${width}"
+            deepspeed --num_gpus $WORLD_SIZE run_trainer.py --lr $lr --width $width --run_name $run_name
+        done
     done
-done
+fi

--- a/run_multi_node.sh
+++ b/run_multi_node.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+HOST_FILE_PATH=$1
+NGPU_PER_NODE=$2
+NUM_NODES=$3
+SINGLE_RUN=$4 # True or False
+export NGPU=$((NGPU_PER_NODE*NUM_NODES))
+export MASTER_PORT=$((NGPU+12345))
+
+echo "HOST_FILE_PATH=$HOST_FILE_PATH"
+echo "NGPU_PER_NODE=$NGPU_PER_NODE"
+echo "NUM_NODES=$NUM_NODES"
+echo "NGPU=$NGPU"
+echo "MASTER_PORT=$MASTER_PORT"
+echo "SINGLE_RUN=$SINGLE_RUN"
+
+if [ "$SINGLE_RUN" = "True" ]; then
+    # single run test
+    deepspeed --master_port $MASTER_PORT --hostfile $HOST_FILE_PATH --num_nodes ${NUM_NODES} --num_gpus ${NGPU} \
+    run_trainer.py \
+    --lr 5e-4 \
+    --width 16 \
+    --run_name "multi_node_test" \
+    --print_profile_results
+else
+    # recursive run
+    lrs=(5e-4, 1e-4)
+    widths=(16 32 64 128)
+
+    for lr in "${lrs[@]}"; do
+        for width in "${widths[@]}"; do
+            run_name="lr_${lr}_width_${width}"
+            deepspeed --master_port $MASTER_PORT --hostfile $HOST_FILE_PATH --num_nodes ${NUM_NODES} --num_gpus ${NGPU} \
+            run_trainer.py \
+            --lr $lr \
+            --width $width \
+            --run_name $run_name
+        done
+    done
+fi


### PR DESCRIPTION
- add script for multi-node training (and update readme a lil bit)
- add memory_profile_utils.py 
- make trainer to use deepspeed logger (not print)

if you use `--print_profile_results`, elapsed time and gpu memory used for 1 step (fwd+bwd+update) are printed

```python
[2024-03-01 18:29:08,370] [INFO] [run_trainer.py:65:train] loss : 10.65136432647705
[2024-03-01 18:29:08,703] [INFO] [logging.py:96:log_dist] [Rank 0] time (ms) | fwd_microstep: 230.74 | bwd_microstep: 331.51 | bwd_inner_microstep: 149.39 | bwd_allreduce_microstep: 182.01 | step_microstep: 0.05
[2024-03-01 18:29:08,854] [INFO] [memory_profile_utils.py:28:get_nvidia_gpu_memory] 
    nvidia-smi info
    [72714]
[2024-03-01 18:29:09,043] [INFO] [memory_profile_utils.py:52:gpu_memory_plot_helper] 
    rank: 0 / device: cuda:0
    CPU Virtual Memory:  used = 67.22 GB, percent = 3.3%
    Allocated / Reserved: 4162.88MB / 23816.00MB
    Max Allocated / Max Reserved: 18706.66MB / 23816.00MB
```